### PR TITLE
updated deprecated finder for redmine 3.0 compatibility, fixed gravatars

### DIFF
--- a/lib/panel_issue_hooks.rb
+++ b/lib/panel_issue_hooks.rb
@@ -17,7 +17,7 @@ class PanelIssueHooks < Redmine::Hook::ViewListener
     back = request.env['HTTP_REFERER']
 
     if (issue_id)
-      issue = Issue.find(issue_id, :include => [:status])
+      issue = Issue.includes(:status).find(issue_id)
       if (issue)
         if (User.current.allowed_to?(:edit_issues, project))
           o = ''
@@ -44,7 +44,20 @@ class PanelIssueHooks < Redmine::Hook::ViewListener
             assignables.each do |u|
               if (u != issue.assigned_to)
                 o << '<tr><td>'
-								# no more gravatar, but fatal error disappear too :)
+                options = {:size => "14", :style => "float: left; margin-right: 2px;"}
+                av = if Setting.gravatar_enabled?
+                  options.merge!({:ssl => (request && request.ssl?), :default => Setting.gravatar_default})
+                  email = nil
+                  if u.respond_to?(:mail)
+                    email = u.mail
+                  elsif u.to_s =~ %r{<(.+?)>}
+                    email = $1
+                  end
+                  gravatar(email.to_s.downcase, options) unless email.blank? rescue ''
+                else
+                  ''
+                end
+                o << av unless av.nil?
                 o << link_to(u.name, {:controller => 'issues', :action => 'update', :id => issue, :issue => {:assigned_to_id => u}, :back_to => "/issues/show/"+issue_id, :authenticity_token => form_authenticity_token(request.session)}, :method => :put)
                 o << '</td></tr>'
               end

--- a/lib/panel_issue_hooks.rb
+++ b/lib/panel_issue_hooks.rb
@@ -36,7 +36,7 @@ class PanelIssueHooks < Redmine::Hook::ViewListener
             end
             o << "</table>"
           end
-          assignables = project.assignable_users
+          assignables = issue.assignable_users
           if (!assignables.empty?) || (!issue.assigned_to.nil?)
             o << "<h3>#{l(:label_issue_change_assigned)}</h3>"
             o << '<div' + (assignables.length > 10 ? ' class="issue_control_panel_scroll">' : '>')


### PR DESCRIPTION
Updated plugin for redmine 3.0.0 version.
Fixed avatars (copied the code from application_helper#avatar so that request object can be actually used).
